### PR TITLE
Fix Quotes API URL and response values

### DIFF
--- a/quote.go
+++ b/quote.go
@@ -2,9 +2,9 @@ package finnhub
 
 // Quote the data structure for quotes
 type Quote struct {
-	Open          int `json:"o"`
-	High          int `json:"h"`
-	Low           int `json:"l"`
-	Current       int `json:"c"`
-	PreviousClose int `json:"pc"`
+	Open          float64 `json:"o"`
+	High          float64 `json:"h"`
+	Low           float64 `json:"l"`
+	Current       float64 `json:"c"`
+	PreviousClose float64 `json:"pc"`
 }

--- a/stock/client.go
+++ b/stock/client.go
@@ -39,7 +39,7 @@ const (
 	URLSymbol = "stock/symbol"
 
 	// URLQuote quote endpoint url
-	URLQuote = "stock/quote"
+	URLQuote = "quote"
 
 	// URLGradings gradings endpoint url
 	URLGradings = "stock/upgrade-downgrade"


### PR DESCRIPTION
Quote URL has changed since implementation and stocks can be also non-integer values